### PR TITLE
Move wasm compiler to run in a web worker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
       with:
         node-version: 18.x
     - uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: wasm32-unknown-unknown
     - uses: Swatinem/rust-cache@v2
     - uses: baptiste0928/cargo-install@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
       with:
         node-version: 18.x
     - uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: wasm32-unknown-unknown
     - uses: Swatinem/rust-cache@v2
     - uses: baptiste0928/cargo-install@v2
       with:

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -43,7 +43,7 @@ wasm = [
     "dep:wasm-bindgen", 
     "dep:wasm-bindgen-futures",
     "dep:js-sys",
-    "web-sys/Window",
+    "web-sys/WorkerGlobalScope",
     "instant/wasm-bindgen",
     "no-async-send",
     "dep:tsify",

--- a/compiler-core/src/util/async_macro_wasm.rs
+++ b/compiler-core/src/util/async_macro_wasm.rs
@@ -1,13 +1,9 @@
 use std::cell::UnsafeCell;
 
-use js_sys::Promise;
+// use js_sys::Promise;
 use log::warn;
-use wasm_bindgen_futures::JsFuture;
-use web_sys::Window;
-
-thread_local! {
-    static WINDOW: Window = web_sys::window().expect("no global `window` exists");
-}
+// use wasm_bindgen_futures::JsFuture;
+// use web_sys::WorkerGlobalScope;
 
 thread_local! {
     static CANCELLED: UnsafeCell<bool> = UnsafeCell::new(false);
@@ -48,12 +44,11 @@ pub async fn set_timeout_yield() -> Result<(), WasmError> {
     if has_budget {
         return Ok(());
     }
-    let promise = WINDOW.with(|window| {
-        Promise::new(&mut |resolve, _| {
-            let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, 0);
-        })
-    });
-    let _ = JsFuture::from(promise).await;
+    // Promise::new(&mut |resolve, _| {
+    //     web_sys::worker_global_scope();
+    //     let _ = WorkerGlobalScope::self_().set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, 0);
+    // });
+    // let _ = JsFuture::from(promise).await;
     CANCELLED.with(|cancelled| unsafe {
         if *cancelled.get() {
             warn!("cancelling...");

--- a/compiler-wasm/build/src/build.rs
+++ b/compiler-wasm/build/src/build.rs
@@ -1,12 +1,21 @@
 //! Build wasm package and copy it to the web-client directory.
 
+use std::borrow::Cow;
 use std::fs;
-use std::io::{self, Write};
+use std::io;
 use std::path::Path;
 use std::process::Command;
 
-/// Output directory relative to the wasm package (not current dir)
-const OUTPUT_DIR: &str = "../web-client/src/low/celerc";
+/// Temporary output directory
+const TEMP_OUTPUT_DIR: &str = "celerc";
+
+const BINDING_TS: &str = "binding.g.ts";
+const CELERCWASM_BG_WASM: &str = "celercwasm_bg.wasm";
+const WORKER_JS: &str = "worker.js";
+
+/// Output directory
+const OUTPUT_PUBLIC_DIR: &str = "../../web-client/public/celerc";
+const OUTPUT_LOW_DIR: &str = "../../web-client/src/low/celerc";
 
 pub fn main() {
     match main_internal() {
@@ -17,19 +26,39 @@ pub fn main() {
 
 fn main_internal() -> io::Result<()> {
     wasm_pack_build()?;
-    override_typescript_definitions()?;
-    add_console_log()?;
+    process_typescript()?;
+
+    println!("copying files");
+    fs::create_dir_all(OUTPUT_PUBLIC_DIR)?;
+    fs::copy(
+        Path::new(TEMP_OUTPUT_DIR).join(BINDING_TS),
+        Path::new(OUTPUT_LOW_DIR).join(BINDING_TS),
+    )?;
+
+    fs::copy(
+        Path::new(TEMP_OUTPUT_DIR).join(WORKER_JS),
+        Path::new(OUTPUT_PUBLIC_DIR).join(WORKER_JS),
+    )?;
+
+    fs::copy(
+        Path::new(TEMP_OUTPUT_DIR).join(CELERCWASM_BG_WASM),
+        Path::new(OUTPUT_PUBLIC_DIR).join(CELERCWASM_BG_WASM),
+    )?;
+
     Ok(())
 }
 
 fn wasm_pack_build() -> io::Result<()> {
-    if let Err(e) = fs::remove_dir_all(OUTPUT_DIR) {
+    if let Err(e) = fs::remove_dir_all(TEMP_OUTPUT_DIR) {
         if e.kind() != io::ErrorKind::NotFound {
             return Err(e);
         }
     }
 
-    let mut command = build_wasm_pack_command();
+    #[cfg(debug_assertions)]
+    let mut command = build_wasm_pack_command(&["--dev"]);
+    #[cfg(not(debug_assertions))]
+    let mut command = build_wasm_pack_command(&["--release"]);
     let result = command.spawn()?.wait_with_output()?;
 
     if !result.status.success() {
@@ -46,46 +75,169 @@ fn wasm_pack_build() -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(debug_assertions)]
-fn build_wasm_pack_command() -> Command {
+fn build_wasm_pack_command(extra_args: &[&str]) -> Command {
     let mut command = Command::new("wasm-pack");
-    command.args(["build", "--out-dir", OUTPUT_DIR, "--dev"]);
+    let out_dir = Path::new("build")
+        .join(TEMP_OUTPUT_DIR)
+        .display()
+        .to_string();
+    let mut args = vec!["build", "--out-dir", &out_dir, "--target", "no-modules"];
+    args.extend(extra_args);
+    command.args(args);
     command.current_dir("..");
     command
 }
 
-#[cfg(not(debug_assertions))]
-fn build_wasm_pack_command() -> Command {
-    let mut command = Command::new("wasm-pack");
-    command.args(&["build", "--out-dir", OUTPUT_DIR, "--release"]);
-    command.current_dir("..");
-    command
-}
-
-fn override_typescript_definitions() -> io::Result<()> {
+fn process_typescript() -> io::Result<()> {
     println!("generating typescript definitions");
-    let path = Path::new("..").join(OUTPUT_DIR).join("celercwasm.d.ts");
+    let path = Path::new(TEMP_OUTPUT_DIR).join("celercwasm.d.ts");
     let d_ts = fs::read_to_string(&path)?;
+    let d_ts = patch_d_ts(d_ts);
+    let mut lines = d_ts.lines();
+    let mut gen_lines = vec![];
+    gen_lines.push(Cow::from(include_str!("./prelude.ts")));
+    let mut funcs = vec![];
+    while let Some(line) = lines.next() {
+        if line == "declare namespace wasm_bindgen {" {
+            for line in lines.by_ref() {
+                if line == "}" {
+                    break;
+                }
+                let line = line.strip_prefix('\t').expect("expecting namespace indent");
+                match line.strip_prefix("export function ") {
+                    None => gen_lines.push(Cow::from(line)),
+                    Some(fn_def) => {
+                        let mut fn_def = fn_def.splitn(2, '(');
+                        let fn_name = fn_def.next().expect("cannot get function name");
+                        let fn_def = fn_def
+                            .next()
+                            .expect("cannot get function args and return type");
+                        let fn_id = funcs.len();
+                        funcs.push(fn_name);
+                        let (args, return_type) = parse_function(fn_def);
+                        let mut fn_gen = String::new();
+                        fn_gen.push_str("export function ");
+                        fn_gen.push_str(fn_name);
+                        fn_gen.push('(');
+                        if !args.is_empty() {
+                            for arg in &args {
+                                fn_gen.push_str(&arg.ident);
+                                fn_gen.push_str(": ");
+                                fn_gen.push_str(&arg.arg_type);
+                                fn_gen.push_str(", ");
+                            }
+                            fn_gen.pop();
+                            fn_gen.pop();
+                        }
+                        fn_gen.push_str("): ");
+                        fn_gen.push_str(&return_type);
+                        fn_gen.push_str(" {");
+                        gen_lines.push(Cow::from(fn_gen));
+                        let mut fn_gen = String::new();
+                        fn_gen.push_str("    ");
+                        if return_type != "void" {
+                            fn_gen.push_str("return ");
+                        }
+                        fn_gen.push_str("callWorker(");
+                        fn_gen.push_str(&fn_id.to_string());
+                        fn_gen.push_str(", [");
+                        if !args.is_empty() {
+                            for arg in &args {
+                                match arg.ident.strip_suffix('?') {
+                                    Some(ident) => {
+                                        fn_gen.push_str(ident);
+                                    }
+                                    None => {
+                                        fn_gen.push_str(&arg.ident);
+                                    }
+                                }
+                                fn_gen.push_str(", ");
+                            }
+                            fn_gen.pop();
+                            fn_gen.pop();
+                        }
+                        fn_gen.push_str("]);");
+                        gen_lines.push(Cow::from(fn_gen));
+                        gen_lines.push(Cow::from("}"));
+                    }
+                }
+            }
+            break;
+        }
+    }
 
-    // https://github.com/madonoharu/tsify/issues/37
-    // tsify doesn't quote properties starting with number correctly
-    let d_ts = d_ts.replace("    2d: ", "    \"2d\": ");
-    let d_ts = d_ts.replace("    3d: ", "    \"3d\": ");
-    fs::write(path, d_ts)?;
+    fs::write(
+        Path::new(TEMP_OUTPUT_DIR).join(BINDING_TS),
+        gen_lines.join("\n"),
+    )?;
+
+    build_worker(&funcs)?;
     Ok(())
 }
 
-fn add_console_log() -> io::Result<()> {
-    // open file for appending
-    let mut file = fs::OpenOptions::new()
-        .append(true)
-        .open(Path::new("..").join(OUTPUT_DIR).join("celercwasm.js"))?;
+fn patch_d_ts(d_ts: String) -> String {
+    // https://github.com/madonoharu/tsify/issues/37
+    // tsify doesn't quote properties starting with number correctly
+    let d_ts = d_ts.replace("    2d: ", "    \"2d\": ");
+    d_ts.replace("    3d: ", "    \"3d\": ")
+}
 
-    // write to file
-    writeln!(
-        file,
-        "window.console.log(\"      loading compiler module\");"
-    )?;
+fn parse_function(mut s: &str) -> (Vec<TsArg>, String) {
+    let mut args = vec![];
 
+    loop {
+        if let Some(rest) = s.strip_prefix("): ") {
+            let return_type = rest
+                .strip_suffix(';')
+                .expect("function definition must end with ;");
+            return (args, return_type.to_string());
+        }
+        let mut rest = s.splitn(2, ':');
+        let ident = rest.next().expect("cannot get identifier name");
+        let rest = rest.next().expect("cannot get arg type");
+        let rest = rest.strip_prefix(' ').expect("malformed function type");
+        // wasm_bindgen output has no generic or functions, which makes parsing simpler
+        let i_comma = rest.find(',');
+        match i_comma {
+            Some(i) => {
+                let arg_type = rest[..i].to_string();
+                args.push(TsArg {
+                    ident: ident.to_string(),
+                    arg_type,
+                });
+                s = &rest[i + 2..];
+            }
+            None => {
+                let i_paren = rest.find(')').expect("malformed function type");
+                let arg_type = rest[..i_paren].to_string();
+                args.push(TsArg {
+                    ident: ident.to_string(),
+                    arg_type,
+                });
+                s = &rest[i_paren..];
+            }
+        }
+    }
+}
+
+struct TsArg {
+    ident: String,
+    arg_type: String,
+}
+
+/// Build worker.js
+fn build_worker(funcs: &[&str]) -> io::Result<()> {
+    println!("generating worker.js");
+    let mut worker_js = fs::read_to_string(Path::new(TEMP_OUTPUT_DIR).join("celercwasm.js"))?;
+    worker_js.push_str("// worker_init.js\n");
+    worker_js.push_str(include_str!("./worker_init.js"));
+    worker_js.push_str("\n__initWorker([\n");
+    for func in funcs {
+        worker_js.push_str("    wasm_bindgen.");
+        worker_js.push_str(func);
+        worker_js.push_str(",\n");
+    }
+    worker_js.push_str("]);\n");
+    fs::write(Path::new(TEMP_OUTPUT_DIR).join(WORKER_JS), worker_js)?;
     Ok(())
 }

--- a/compiler-wasm/build/src/prelude.ts
+++ b/compiler-wasm/build/src/prelude.ts
@@ -1,0 +1,3 @@
+//! Generated definition from compiler-wasm
+/* eslint-disable */
+import { callWorker } from "low/utils";

--- a/compiler-wasm/build/src/prelude.ts
+++ b/compiler-wasm/build/src/prelude.ts
@@ -1,3 +1,2 @@
 //! Generated definition from compiler-wasm
-/* eslint-disable */
 import { callWorker } from "low/utils";

--- a/compiler-wasm/build/src/worker_init.js
+++ b/compiler-wasm/build/src/worker_init.js
@@ -1,0 +1,62 @@
+async function __initWorker(HANDLERS) {
+    await wasm_bindgen("/celerc/celercwasm_bg.wasm");
+
+    const pendingFiles = {};
+
+    function workerOnReady() {
+        wasm_bindgen.init(
+            self.location.origin,
+            (x) => self.postMessage(["info_fn", undefined, x]),
+            (x) => self.postMessage(["warn_fn", undefined, x]),
+            (x) => self.postMessage(["error_fn", undefined, x]),
+            (x) => {
+                return new Promise((resolve, reject) => {
+                    setTimeout(() => {
+                        pendingFiles[x] = [resolve, reject];
+                        self.postMessage(["load_file", undefined, x]);
+                    }, 0);
+                });
+            },
+            async (url) => {
+                for (let i = 0; i < 3; i++) {
+                    const response = await fetch(url);
+                    if (!response.ok) {
+                        await new Promise((resolve) => {
+                            setTimeout(resolve, 1000);
+                        });
+                        continue;
+                    }
+                    const data = await response.arrayBuffer();
+                    return new Uint8Array(data);
+                }
+                throw new Error(`failed to fetch ${url}`);
+            }
+        );
+    }
+
+    self.onmessage = async (event) => {
+        const [msgId, funcId, args] = event.data;
+        if (msgId === "ready") {
+            // ["ready"]
+            workerOnReady();
+            self.postMessage(["info_fn", undefined, "compiler worker ready"]);
+            self.postMessage(["ready"]);
+            return;
+        }
+        if (msgId === "file") {
+            // ["file", 0, [path, data]]
+            // ["file", 1, [path, error]]
+            const handler = pendingFiles[args[0]][funcId];
+            delete pendingFiles[args];
+            setTimeout(() => handler(args[1]), 0);
+            return;
+        }
+        try {
+            const handler = HANDLERS[funcId];
+            const result = await handler(...args);
+            self.postMessage([msgId, true, result]);
+        } catch (e) {
+            self.postMessage([msgId, false, e]);
+        }
+    };
+}

--- a/web-client/.gitignore
+++ b/web-client/.gitignore
@@ -28,3 +28,4 @@ dist-ssr
 
 # cache
 .eslintcache
+public/celerc/

--- a/web-client/src/core/kernel/editor/CompMgr.ts
+++ b/web-client/src/core/kernel/editor/CompMgr.ts
@@ -1,6 +1,6 @@
 import { AppDispatcher, documentActions, viewActions } from "core/store";
-import { init, compile_document } from "low/celerc";
-import { Debouncer, Logger, wrapAsync, console } from "low/utils";
+import { compile_document } from "low/celerc";
+import { Debouncer, Logger, wrapAsync, console, setWorker } from "low/utils";
 
 const CompilerLog = new Logger("com");
 
@@ -29,16 +29,10 @@ export class CompMgr {
 
     public async init(
         loadFile: RequestFileFunction,
-        loadUrl: RequestFileFunction,
     ) {
-        init(
-            window.location.origin,
-            (x: string) => CompilerLog.info(x),
-            (x: string) => CompilerLog.warn(x),
-            (x: string) => CompilerLog.error(x),
-            loadFile,
-            loadUrl,
-        );
+        CompilerLog.info("initializing compiler worker...");
+        const worker = new Worker("/celerc/worker.js");
+        await setWorker(worker, CompilerLog, loadFile);
     }
 
     /// Trigger compilation of the document

--- a/web-client/src/core/kernel/editor/EditorKernelImpl.ts
+++ b/web-client/src/core/kernel/editor/EditorKernelImpl.ts
@@ -11,7 +11,6 @@ import {
     settingsActions,
 } from "core/store";
 import { EntryPointsSorted, get_entry_points } from "low/celerc";
-import { fetchAsBytes } from "low/fetch";
 import { FileSys, FsResult } from "low/fs";
 import { Result, allocOk, isInDarkMode, sleep, wrapAsync } from "low/utils";
 
@@ -85,10 +84,7 @@ export class EditorKernelImpl implements EditorKernel {
     }
 
     public async init(): Promise<void> {
-        await this.compMgr.init(
-            this.fileMgr.getFileAsBytes.bind(this.fileMgr),
-            fetchAsBytes,
-        );
+        await this.compMgr.init(this.fileMgr.getFileAsBytes.bind(this.fileMgr));
     }
 
     /// Reset the editor with a new file system. Unsaved changes will be lost

--- a/web-client/src/low/celerc/index.ts
+++ b/web-client/src/low/celerc/index.ts
@@ -1,0 +1,1 @@
+export * from "./binding.g.ts";

--- a/web-client/src/low/utils/WorkerHost.ts
+++ b/web-client/src/low/utils/WorkerHost.ts
@@ -1,0 +1,72 @@
+import { Logger } from "./Logger";
+
+let worker: Worker;
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const specialHandlers: { [key: string]: (data: any) => any } = {};
+const workerHandlers: { [key: number]: [(x: any) => void, (x: any) => void] } = {};
+let nextId = 0;
+
+export type LoadFileFn = (path: string) => Promise<Uint8Array>;
+
+/// Set the worker and post the "ready" message
+export function setWorker(w: Worker, logger: Logger, loadFile: LoadFileFn ) {
+    if (worker) {
+        worker.terminate();
+    }
+    worker = w;
+    specialHandlers["info_fn"] = logger.info.bind(logger);
+    specialHandlers["warn_fn"] = logger.warn.bind(logger);
+    specialHandlers["error_fn"] = logger.error.bind(logger);
+    specialHandlers["load_file"] = async (x: string) => {
+        try {
+            const result = await loadFile(x);
+            worker.postMessage(["file", 0, [x, result]]);
+        } catch (e) {
+            worker.postMessage(["file", 1, [x, e]]);
+        }
+    };
+    worker.onmessage = (e) => {
+        const [handleId, ok, result] = e.data;
+        if (typeof handleId === "string") {
+            // Special handler
+            const handler = specialHandlers[handleId];
+            if (handler) {
+                handler(result);
+            }
+        } else {
+            // Event handler
+            const [resolve, reject] = workerHandlers[handleId];
+            delete workerHandlers[handleId];
+            if (ok) {
+                resolve(result);
+            } else {
+                reject(result);
+            }
+        }
+    }
+    worker.onerror = (e) => {
+        console.error(e);
+    }
+    return new Promise((resolve) => {
+        let handle: any;
+        specialHandlers["ready"] = () => {
+            clearTimeout(handle);
+            resolve(undefined);
+        };
+        function postReady() {
+            logger.info("waiting for worker to be ready...");
+            worker.postMessage(["ready"]);
+            clearTimeout(handle);
+            handle = setTimeout(postReady, 100);
+        }
+        postReady();
+    });
+}
+
+/// Call a worker function
+export function callWorker<T>(funcId: number, args: any[]): Promise<T> {
+    return new Promise((resolve, reject) => {
+        workerHandlers[nextId] = [resolve, reject];
+        worker.postMessage([nextId++, funcId, args]);
+    });
+}

--- a/web-client/src/low/utils/index.ts
+++ b/web-client/src/low/utils/index.ts
@@ -7,6 +7,7 @@ export * from "./Debouncer";
 export * from "./Pool";
 export * from "./FileSaver";
 export * from "./Result";
+export * from "./WorkerHost";
 export * from "./yielder";
 
 export const isInDarkMode = () =>

--- a/web-client/src/ui/doc/DocRoot.tsx
+++ b/web-client/src/ui/doc/DocRoot.tsx
@@ -21,7 +21,8 @@ import { DocController, initDocController } from "./DocController";
 import { Rich } from "./Rich";
 
 export const DocRoot: React.FC = () => {
-    const { stageMode, isEditingLayout, compileInProgress } = useSelector(viewSelector);
+    const { stageMode, isEditingLayout, compileInProgress } =
+        useSelector(viewSelector);
     const { document, serial } = useSelector(documentSelector);
     const store = useStore();
     const controller = useMemo(() => {

--- a/web-client/src/ui/doc/DocRoot.tsx
+++ b/web-client/src/ui/doc/DocRoot.tsx
@@ -21,7 +21,7 @@ import { DocController, initDocController } from "./DocController";
 import { Rich } from "./Rich";
 
 export const DocRoot: React.FC = () => {
-    const { stageMode, isEditingLayout } = useSelector(viewSelector);
+    const { stageMode, isEditingLayout, compileInProgress } = useSelector(viewSelector);
     const { document, serial } = useSelector(documentSelector);
     const store = useStore();
     const controller = useMemo(() => {
@@ -29,7 +29,7 @@ export const DocRoot: React.FC = () => {
     }, [store]);
 
     if (!document) {
-        if (stageMode === "edit") {
+        if (stageMode === "edit" && !compileInProgress) {
             return (
                 <div className="blank-div-message">
                     Doc will be shown here once a project is opened

--- a/web-client/src/ui/map/MapRoot.tsx
+++ b/web-client/src/ui/map/MapRoot.tsx
@@ -13,7 +13,7 @@ import { RootContainerId } from "./MapContainerMgr";
 /// Map root container that the leaflet map instance binds to
 export const MapRoot: React.FC = () => {
     const { serial, document } = useSelector(documentSelector);
-    const { stageMode } = useSelector(viewSelector);
+    const { stageMode, compileInProgress } = useSelector(viewSelector);
     const store = useStore();
     const mapState = useRef<MapState | null>(null);
     /* eslint-disable react-hooks/exhaustive-deps*/
@@ -30,7 +30,7 @@ export const MapRoot: React.FC = () => {
     /* eslint-enable react-hooks/exhaustive-deps*/
 
     if (!document) {
-        if (stageMode === "edit") {
+        if (stageMode === "edit" && !compileInProgress) {
             return (
                 <div className="blank-div-message">
                     Map will be shown here once a project is opened


### PR DESCRIPTION
Part of #78 
The yielding is temporarily disabled due to web_sys not able to access WorkerGlobalScope directly (what the heck?) This will be fixed when I clean up async_for for wasm and run tokio inside wasm