### PR TITLE
Refactor DocRichText and DocPoorText

### DIFF
--- a/compiler-core/src/comp/comp_doc.rs
+++ b/compiler-core/src/comp/comp_doc.rs
@@ -15,7 +15,7 @@ use super::{CompError, CompLine, CompSection, Compiler};
 #[serde(rename_all = "camelCase")]
 pub struct CompDoc {
     /// The preface
-    pub preface: Vec<Vec<DocRichText>>,
+    pub preface: Vec<DocRichText>,
     /// The route
     pub route: Vec<CompSection>,
     /// Overall diagnostics (that don't apply to any line)
@@ -58,7 +58,7 @@ impl<'a> Compiler<'a> {
 
     async fn add_section_or_preface(
         &mut self,
-        preface: &mut Vec<Vec<DocRichText>>,
+        preface: &mut Vec<DocRichText>,
         route: &mut Vec<CompSection>,
         value: PackerValue,
     ) -> Result<(), CompError> {

--- a/compiler-core/src/comp/comp_line.rs
+++ b/compiler-core/src/comp/comp_line.rs
@@ -7,7 +7,7 @@ use crate::json::Coerce;
 use crate::lang;
 use crate::lang::PresetInst;
 use crate::prop;
-use crate::types::{DocDiagnostic, DocNote, DocRichText, GameCoord, DocRichTextBlock};
+use crate::types::{DocDiagnostic, DocNote, DocRichText, DocRichTextBlock, GameCoord};
 
 use super::{
     validate_not_array_or_object, CompError, CompMarker, CompMovement, Compiler, CompilerResult,
@@ -615,7 +615,7 @@ mod test {
             }),
             CompLine {
                 text: DocRichText::text("foo"),
-                split_name: Some(vec![]),
+                split_name: Some(DocRichText(vec![])),
                 ..Default::default()
             },
         );
@@ -832,8 +832,8 @@ mod test {
             &mut compiler,
             json!("_preset::four< abcde >"),
             CompLine {
-                text: vec![DocRichText::text("preset four: arg is  abcde ")],
-                secondary_text: vec![DocRichText::text("preset two")],
+                text: DocRichText::text("preset four: arg is  abcde "),
+                secondary_text: DocRichText::text("preset two"),
                 ..Default::default()
             },
         );
@@ -842,7 +842,7 @@ mod test {
             &mut compiler,
             json!("_preset::overflow"),
             CompLine {
-                text: vec![DocRichText::text("_preset::overflow")],
+                text: DocRichText::text("_preset::overflow"),
                 ..Default::default()
             },
             vec![CompError::MaxPresetDepthExceeded(
@@ -863,7 +863,7 @@ mod test {
                 },
             }),
             CompLine {
-                text: vec![DocRichText::text("icon is string")],
+                text: DocRichText::text("icon is string"),
                 doc_icon: Some("my-icon".to_string()),
                 map_icon: Some("my-icon".to_string()),
                 ..Default::default()
@@ -878,7 +878,7 @@ mod test {
                 },
             }),
             CompLine {
-                text: vec![DocRichText::text("icon is string")],
+                text: DocRichText::text("icon is string"),
                 ..Default::default()
             },
             vec![
@@ -895,7 +895,7 @@ mod test {
                 },
             }),
             CompLine {
-                text: vec![DocRichText::text("icon is array")],
+                text: DocRichText::text("icon is array"),
                 ..Default::default()
             },
             vec![
@@ -912,7 +912,7 @@ mod test {
                 },
             }),
             CompLine {
-                text: vec![DocRichText::text("icon is empty object")],
+                text: DocRichText::text("icon is empty object"),
                 ..Default::default()
             },
             vec![
@@ -931,7 +931,7 @@ mod test {
                 },
             }),
             CompLine {
-                text: vec![DocRichText::text("icon all 3")],
+                text: DocRichText::text("icon all 3"),
                 doc_icon: Some("my-doc-icon".to_string()),
                 map_icon: Some("my-map-icon".to_string()),
                 map_icon_priority: 1,
@@ -950,7 +950,7 @@ mod test {
                 },
             }),
             CompLine {
-                text: vec![DocRichText::text("icon is object")],
+                text: DocRichText::text("icon is object"),
                 properties: btree_map! {
                     "icon-boo".to_string() => json!("foo"),
                 },
@@ -978,7 +978,7 @@ mod test {
                 },
             }),
             CompLine {
-                text: vec![DocRichText::text("icon is partial")],
+                text: DocRichText::text("icon is partial"),
                 doc_icon: None,
                 map_icon: Some("my-map-icon".to_string()),
                 map_icon_priority: 10,
@@ -1008,7 +1008,7 @@ mod test {
                 },
             }),
             CompLine {
-                text: vec![DocRichText::text("_Example")],
+                text: DocRichText::text("_Example"),
                 map_icon: None,
                 doc_icon: Some("my-doc-icon".to_string()),
                 ..Default::default()
@@ -1023,7 +1023,7 @@ mod test {
                 },
             }),
             CompLine {
-                text: vec![DocRichText::text("_Example")],
+                text: DocRichText::text("_Example"),
                 doc_icon: None,
                 map_icon: Some("my-map-icon".to_string()),
                 ..Default::default()
@@ -1043,8 +1043,8 @@ mod test {
                 },
             }),
             CompLine {
-                text: vec![DocRichText::text("counter is string")],
-                counter_text: Some(DocRichText::text("hello")),
+                text: DocRichText::text("counter is string"),
+                counter_text: Some(DocRichTextBlock::text("hello")),
                 ..Default::default()
             },
         );
@@ -1057,8 +1057,8 @@ mod test {
                 },
             }),
             CompLine {
-                text: vec![DocRichText::text("counter is tagged string")],
-                counter_text: Some(DocRichText::with_tag("test", "hello")),
+                text: DocRichText::text("counter is tagged string"),
+                counter_text: Some(DocRichTextBlock::with_tag("test", "hello")),
                 ..Default::default()
             },
         );
@@ -1071,8 +1071,8 @@ mod test {
                 },
             }),
             CompLine {
-                text: vec![DocRichText::text("counter is empty tagged string")],
-                counter_text: Some(DocRichText::with_tag("test", "")),
+                text: DocRichText::text("counter is empty tagged string"),
+                counter_text: Some(DocRichTextBlock::with_tag("test", "")),
                 ..Default::default()
             },
         );
@@ -1085,7 +1085,7 @@ mod test {
                 },
             }),
             CompLine {
-                text: vec![DocRichText::text("counter is empty string")],
+                text: DocRichText::text("counter is empty string"),
                 counter_text: None,
                 ..Default::default()
             },
@@ -1099,7 +1099,7 @@ mod test {
                 },
             }),
             CompLine {
-                text: vec![DocRichText::text("counter is invalid")],
+                text: DocRichText::text("counter is invalid"),
                 ..Default::default()
             },
             vec![CompError::InvalidLinePropertyType("counter".to_string())],
@@ -1109,12 +1109,12 @@ mod test {
             &mut compiler,
             json!({
                 "counter is more than one text block": {
-                    "counter": ".v(hello) ",
+                    "counter": ".v(hello) foo",
                 },
             }),
             CompLine {
-                text: vec![DocRichText::text("counter is more than one text block")],
-                counter_text: Some(DocRichText::with_tag("v", "hello")),
+                text: DocRichText::text("counter is more than one text block"),
+                counter_text: Some(DocRichTextBlock::with_tag("v", "hello")),
                 ..Default::default()
             },
             vec![CompError::TooManyTagsInCounter],
@@ -1134,7 +1134,7 @@ mod test {
             &mut compiler,
             json!("no color or coord"),
             CompLine {
-                text: vec![DocRichText::text("no color or coord")],
+                text: DocRichText::text("no color or coord"),
                 line_color: "color".to_string(),
                 map_coord: GameCoord(1.0, 2.0, 3.0),
                 ..Default::default()
@@ -1159,7 +1159,7 @@ mod test {
                 }
             }),
             CompLine {
-                text: vec![DocRichText::text("change color")],
+                text: DocRichText::text("change color"),
                 line_color: "new-color".to_string(),
                 map_coord: GameCoord(1.0, 2.0, 3.0),
                 ..Default::default()
@@ -1174,7 +1174,7 @@ mod test {
                 }
             }),
             CompLine {
-                text: vec![DocRichText::text("change color 2")],
+                text: DocRichText::text("change color 2"),
                 line_color: "new-color".to_string(),
                 map_coord: GameCoord(1.0, 2.0, 3.0),
                 ..Default::default()
@@ -1209,7 +1209,7 @@ mod test {
                 }
             }),
             CompLine {
-                text: vec![DocRichText::text("change coord")],
+                text: DocRichText::text("change coord"),
                 map_coord: GameCoord(4.0, 5.0, 6.0),
                 movements: vec![CompMovement::to(GameCoord(4.0, 5.0, 6.0))],
                 ..Default::default()
@@ -1230,7 +1230,7 @@ mod test {
                 }
             }),
             CompLine {
-                text: vec![DocRichText::text("push pop")],
+                text: DocRichText::text("push pop"),
                 map_coord: GameCoord(1.0, 2.0, 3.0),
                 movements: vec![
                     CompMovement::Push,
@@ -1250,7 +1250,7 @@ mod test {
                 }
             }),
             CompLine {
-                text: vec![DocRichText::text("invalid")],
+                text: DocRichText::text("invalid"),
                 map_coord: GameCoord(1.0, 2.0, 3.0),
                 ..Default::default()
             },
@@ -1297,7 +1297,7 @@ mod test {
                 }
             }),
             CompLine {
-                text: vec![DocRichText::text("preset")],
+                text: DocRichText::text("preset"),
                 map_coord: GameCoord(7.0, 8.0, 9.0),
                 movements: vec![
                     CompMovement::to(GameCoord(3.0, 4.0, 5.0)),
@@ -1324,7 +1324,7 @@ mod test {
                 }
             }),
             CompLine {
-                text: vec![DocRichText::text("test markers")],
+                text: DocRichText::text("test markers"),
                 markers: vec![
                     CompMarker {
                         at: GameCoord(1.0, 2.0, 4.0),
@@ -1344,7 +1344,7 @@ mod test {
                 }
             }),
             CompLine {
-                text: vec![DocRichText::text("test markers invalid type")],
+                text: DocRichText::text("test markers invalid type"),
                 ..Default::default()
             },
             vec![CompError::InvalidLinePropertyType("markers".to_string())],
@@ -1360,7 +1360,7 @@ mod test {
                 }
             }),
             CompLine {
-                text: vec![DocRichText::text("test markers invalid marker type")],
+                text: DocRichText::text("test markers invalid marker type"),
                 ..Default::default()
             },
             vec![CompError::InvalidMarkerType],
@@ -1379,7 +1379,7 @@ mod test {
                 }
             }),
             CompLine {
-                text: vec![DocRichText::text("test")],
+                text: DocRichText::text("test"),
                 properties: [("unused".to_string(), json!("property"))]
                     .into_iter()
                     .collect(),

--- a/compiler-core/src/exec/exec_doc.rs
+++ b/compiler-core/src/exec/exec_doc.rs
@@ -44,7 +44,7 @@ mod test {
             ..Default::default()
         };
 
-        let test_preface = vec![vec![DocRichText::text("test")]];
+        let test_preface = vec![DocRichText::text("test")];
 
         let test_diagnostics = vec![DocDiagnostic {
             msg: parse_poor("test msg"),

--- a/compiler-core/src/exec/exec_line.rs
+++ b/compiler-core/src/exec/exec_line.rs
@@ -86,6 +86,7 @@ impl CompLine {
             .split_name
             .map(|v| v.into_iter().map(|v| v.text).collect::<Vec<_>>().join(""));
         ExecLine {
+            is_banner: false, //self.text.starts_with("(==)"),
             section: section_number,
             index: line_number,
             text: self.text,

--- a/compiler-core/src/exec/exec_line.rs
+++ b/compiler-core/src/exec/exec_line.rs
@@ -82,9 +82,7 @@ impl CompLine {
             }
         }
 
-        let split_name = self
-            .split_name
-            .map(|v| v.into_iter().map(|v| v.text).collect::<Vec<_>>().join(""));
+        let split_name = self.split_name.map(|x| x.to_string());
         ExecLine {
             is_banner: false, //self.text.starts_with("(==)"),
             section: section_number,
@@ -105,7 +103,10 @@ impl CompLine {
 #[cfg(test)]
 mod test {
     use crate::comp::{CompMarker, CompMovement};
-    use crate::types::{DocDiagnostic, DocNote, DocPoorText, DocRichText, GameCoord, MapLine};
+    use crate::types::{
+        DocDiagnostic, DocNote, DocPoorText, DocPoorTextBlock, DocRichText, DocRichTextBlock,
+        GameCoord, MapLine,
+    };
 
     use super::*;
 
@@ -158,59 +159,59 @@ mod test {
     #[test]
     fn test_copy() {
         let mut map_section = Default::default();
-        let test_text = vec![
-            DocRichText {
+        let test_text = DocRichText(vec![
+            DocRichTextBlock {
                 tag: None,
                 text: "test1".to_string(),
                 link: None,
             },
-            DocRichText {
+            DocRichTextBlock {
                 tag: Some("test tag".to_string()),
                 text: "test2".to_string(),
                 link: Some("test link".to_string()),
             },
-        ];
+        ]);
         let test_color = "test color".to_string();
         let test_diagnostics = vec![DocDiagnostic {
-            msg: vec![
-                DocPoorText::Text("test msg1".to_string()),
-                DocPoorText::Link("test link".to_string()),
-            ],
+            msg: DocPoorText(vec![
+                DocPoorTextBlock::Text("test msg1".to_string()),
+                DocPoorTextBlock::Link("test link".to_string()),
+            ]),
             msg_type: "test msg type".to_string(),
             source: "test msg source".to_string(),
         }];
         let test_doc_icon = Some("test-icon".to_string());
-        let test_secondary_text = vec![
-            DocRichText {
+        let test_secondary_text = DocRichText(vec![
+            DocRichTextBlock {
                 tag: None,
                 text: "secondary test1".to_string(),
                 link: None,
             },
-            DocRichText {
+            DocRichTextBlock {
                 tag: Some("secondary test tag".to_string()),
                 text: "secondary test2".to_string(),
                 link: Some("secondary test link".to_string()),
             },
-        ];
-        let test_counter_text = Some(DocRichText {
+        ]);
+        let test_counter_text = Some(DocRichTextBlock {
             tag: Some("counter test tag".to_string()),
             text: "counter test".to_string(),
             link: None,
         });
         let test_notes = vec![
             DocNote::Text {
-                content: vec![
-                    DocRichText {
+                content: DocRichText(vec![
+                    DocRichTextBlock {
                         tag: None,
                         text: "note test1".to_string(),
                         link: None,
                     },
-                    DocRichText {
+                    DocRichTextBlock {
                         tag: Some("note test tag".to_string()),
                         text: "note test2".to_string(),
                         link: Some("note test link".to_string()),
                     },
-                ],
+                ]),
             },
             DocNote::Image {
                 link: "note test src image".to_string(),
@@ -413,23 +414,23 @@ mod test {
 
     #[test]
     fn test_split_name() {
-        let test_split_name = vec![
-            DocRichText {
+        let test_split_name = DocRichText(vec![
+            DocRichTextBlock {
                 tag: None,
                 text: "test1".to_string(),
                 link: None,
             },
-            DocRichText {
+            DocRichTextBlock {
                 tag: Some("something".to_string()),
                 text: " test ".to_string(),
                 link: None,
             },
-            DocRichText {
+            DocRichTextBlock {
                 tag: None,
                 text: "test3".to_string(),
                 link: None,
             },
-        ];
+        ]);
 
         let test_line = CompLine {
             split_name: Some(test_split_name.clone()),

--- a/compiler-core/src/lang/poor/ext.rs
+++ b/compiler-core/src/lang/poor/ext.rs
@@ -1,0 +1,20 @@
+//! Implementations for extended utils of [`DocPoorText`]
+
+use crate::types::{DocPoorText, DocPoorTextBlock};
+
+impl DocPoorText {
+    #[inline]
+    pub fn iter(&self) -> impl Iterator<Item = &DocPoorTextBlock> {
+        self.0.iter()
+    }
+}
+
+impl IntoIterator for DocPoorText {
+    type Item = DocPoorTextBlock;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}

--- a/compiler-core/src/lang/poor/mod.rs
+++ b/compiler-core/src/lang/poor/mod.rs
@@ -1,0 +1,5 @@
+//! Poor string
+mod ext;
+pub use ext::*;
+mod parse;
+pub use parse::parse_poor;

--- a/compiler-core/src/lang/poor/parse.rs
+++ b/compiler-core/src/lang/poor/parse.rs
@@ -62,7 +62,9 @@ mod test {
         );
         assert_eq!(
             parse_poor("hello world https"),
-            DocPoorText(vec![DocPoorTextBlock::Text("hello world https".to_string())])
+            DocPoorText(vec![DocPoorTextBlock::Text(
+                "hello world https".to_string()
+            )])
         );
     }
 
@@ -126,7 +128,9 @@ mod test {
     fn test_just_http() {
         assert_eq!(
             parse_poor("hello world https://"),
-            DocPoorText(vec![DocPoorTextBlock::Text("hello world https://".to_string()),])
+            DocPoorText(vec![DocPoorTextBlock::Text(
+                "hello world https://".to_string()
+            ),])
         );
     }
 }

--- a/compiler-core/src/lang/rich/ext.rs
+++ b/compiler-core/src/lang/rich/ext.rs
@@ -1,0 +1,70 @@
+//! Rich text extensions
+use crate::types::DocRichText;
+
+pub trait RichTextExt {
+    fn starts_with(&self, text: &str) -> bool;
+}
+
+impl RichTextExt for Vec<DocRichText> {
+    fn starts_with(&self, mut text: &str) -> bool {
+        if text.is_empty() {
+            return true;
+        }
+        for block in self {
+            let t = &block.text;
+            let l = t.len();
+            if text.len() < l {
+                return t.starts_with(text);
+            }
+            if text.starts_with(t) {
+                text = &text[l..];
+            } else {
+                return false;
+            }
+        }
+
+        text.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::lang::parse_rich;
+
+    use super::*;
+
+    fn test_a_starts_with_b(a: &str, b: &str) -> bool {
+        parse_rich(a).starts_with(b)
+    }
+
+    #[test]
+    fn test_empty() {
+        assert!(test_a_starts_with_b("", ""));
+        assert!(test_a_starts_with_b("hello", ""));
+        assert!(test_a_starts_with_b(".tag(hello)", ""));
+
+        assert!(!test_a_starts_with_b("", "x"));
+    }
+
+    #[test]
+    fn test_first_block_match() {
+        assert!(test_a_starts_with_b("hello", "hel"));
+        assert!(test_a_starts_with_b("hello", "hello"));
+        assert!(test_a_starts_with_b(".tag(hello)", "h"));
+
+        assert!(!test_a_starts_with_b("hello", "x"));
+        assert!(!test_a_starts_with_b("hello", "xyzws"));
+        assert!(!test_a_starts_with_b(".tag(hello)", "xxx"));
+    }
+
+    #[test]
+    fn test_many_blocks_match() {
+        assert!(test_a_starts_with_b("hello .tag(xxx)", "hello x"));
+        assert!(test_a_starts_with_b("hello .tag(xxx)", "hello xxx"));
+        assert!(test_a_starts_with_b(".tag(hello) xxx", "hello xxx"));
+
+        assert!(!test_a_starts_with_b("hello .tag(yyy)", "hello x"));
+        assert!(!test_a_starts_with_b("hello. tag(yyy)", "hello yyya"));
+        assert!(!test_a_starts_with_b(".tag(hello) yyy", "hello x"));
+    }
+}

--- a/compiler-core/src/lang/rich/ext.rs
+++ b/compiler-core/src/lang/rich/ext.rs
@@ -1,44 +1,79 @@
-//! Rich text extensions
-use crate::types::DocRichText;
+//! Implementation for extended utils of [`DocRichText`]
+use std::fmt::Display;
 
-pub trait RichTextExt {
-    fn starts_with(&self, text: &str) -> bool;
-}
+use crate::types::{DocRichText, DocRichTextBlock};
 
-impl RichTextExt for Vec<DocRichText> {
-    fn starts_with(&self, mut text: &str) -> bool {
-        if text.is_empty() {
+impl DocRichText {
+    /// Create a new [`DocRichText`] with a single [`DocRichTextBlock`] with the text content and
+    /// no tags
+    #[inline]
+    pub fn text(text: &str) -> Self {
+        Self(vec![DocRichTextBlock::text(text)])
+    }
+
+    /// Iterate over the [`DocRichTextBlock`]s
+    #[inline]
+    pub fn iter(&self) -> impl Iterator<Item = &DocRichTextBlock> {
+        self.0.iter()
+    }
+
+    /// Iterate over the [`DocRichTextBlock`]s
+    #[inline]
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut DocRichTextBlock> {
+        self.0.iter_mut()
+    }
+
+    /// Test if the text starts with the given prefix. Tags are ignored.
+    pub fn starts_with(&self, mut prefix: &str) -> bool {
+        if prefix.is_empty() {
             return true;
         }
-        for block in self {
+        for block in self.iter() {
             let t = &block.text;
             let l = t.len();
-            if text.len() < l {
-                return t.starts_with(text);
+            if prefix.len() < l {
+                return t.starts_with(prefix);
             }
-            if text.starts_with(t) {
-                text = &text[l..];
+            if prefix.starts_with(t) {
+                prefix = &prefix[l..];
             } else {
                 return false;
             }
         }
 
-        text.is_empty()
+        prefix.is_empty()
+    }
+}
+
+impl Display for DocRichText {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for block in self.iter() {
+            write!(f, "{}", block.text)?;
+        }
+        Ok(())
+    }
+}
+
+impl IntoIterator for DocRichText {
+    type Item = DocRichTextBlock;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 
 #[cfg(test)]
 mod test {
-    use crate::lang::parse_rich;
-
-    use super::*;
+    use crate::lang;
 
     fn test_a_starts_with_b(a: &str, b: &str) -> bool {
-        parse_rich(a).starts_with(b)
+        lang::parse_rich(a).starts_with(b)
     }
 
     #[test]
-    fn test_empty() {
+    fn test_starts_with_empty() {
         assert!(test_a_starts_with_b("", ""));
         assert!(test_a_starts_with_b("hello", ""));
         assert!(test_a_starts_with_b(".tag(hello)", ""));
@@ -47,7 +82,7 @@ mod test {
     }
 
     #[test]
-    fn test_first_block_match() {
+    fn test_starts_with_first_block_match() {
         assert!(test_a_starts_with_b("hello", "hel"));
         assert!(test_a_starts_with_b("hello", "hello"));
         assert!(test_a_starts_with_b(".tag(hello)", "h"));
@@ -58,7 +93,7 @@ mod test {
     }
 
     #[test]
-    fn test_many_blocks_match() {
+    fn test_starts_with_many_blocks_match() {
         assert!(test_a_starts_with_b("hello .tag(xxx)", "hello x"));
         assert!(test_a_starts_with_b("hello .tag(xxx)", "hello xxx"));
         assert!(test_a_starts_with_b(".tag(hello) xxx", "hello xxx"));

--- a/compiler-core/src/lang/rich/mod.rs
+++ b/compiler-core/src/lang/rich/mod.rs
@@ -1,6 +1,6 @@
 //! Rich string
-mod grammar;
 mod ext;
-pub use ext::RichTextExt;
+mod grammar;
+pub use ext::*;
 mod parse;
 pub use parse::parse_rich;

--- a/compiler-core/src/lang/rich/mod.rs
+++ b/compiler-core/src/lang/rich/mod.rs
@@ -1,4 +1,6 @@
 //! Rich string
 mod grammar;
+mod ext;
+pub use ext::RichTextExt;
 mod parse;
 pub use parse::parse_rich;

--- a/compiler-core/src/plug/link.rs
+++ b/compiler-core/src/plug/link.rs
@@ -7,7 +7,7 @@ use crate::comp::CompDoc;
 use crate::macros::async_trait;
 use crate::pack::PackerResult;
 use crate::prop;
-use crate::types::{DocColor, DocRichText, DocTag};
+use crate::types::{DocColor, DocRichText, DocTag, DocRichTextBlock};
 
 use super::{operation, PlugResult, PluginRuntime};
 
@@ -55,7 +55,7 @@ impl PluginRuntime for LinkPlugin {
     }
 }
 
-fn transform_link_tag(rich_text: &mut DocRichText) {
+fn transform_link_tag(rich_text: &mut DocRichTextBlock) {
     if rich_text
         .tag
         .as_ref()

--- a/compiler-core/src/plug/link.rs
+++ b/compiler-core/src/plug/link.rs
@@ -7,7 +7,7 @@ use crate::comp::CompDoc;
 use crate::macros::async_trait;
 use crate::pack::PackerResult;
 use crate::prop;
-use crate::types::{DocColor, DocRichText, DocTag, DocRichTextBlock};
+use crate::types::{DocColor, DocRichTextBlock, DocTag};
 
 use super::{operation, PlugResult, PluginRuntime};
 
@@ -89,7 +89,7 @@ mod test {
 
     #[test]
     fn test_ignore_no_tag() {
-        let mut text = DocRichText::text("hello world");
+        let mut text = DocRichTextBlock::text("hello world");
         let expected = text.clone();
         transform_link_tag(&mut text);
         assert_eq!(expected, text);
@@ -97,7 +97,7 @@ mod test {
 
     #[test]
     fn test_ignore_link() {
-        let mut text = DocRichText {
+        let mut text = DocRichTextBlock {
             tag: Some("link".to_string()),
             text: "hello world".to_string(),
             link: Some("https://example.com".to_string()),
@@ -109,7 +109,7 @@ mod test {
 
     #[test]
     fn test_ignore_non_link_tag() {
-        let mut text = DocRichText {
+        let mut text = DocRichTextBlock {
             tag: Some("test".to_string()),
             text: "hello world".to_string(),
             link: None,
@@ -121,7 +121,7 @@ mod test {
 
     #[test]
     fn test_transform_link_tag() {
-        let mut text = DocRichText {
+        let mut text = DocRichTextBlock {
             tag: Some(prop::LINK.to_string()),
             text: "hello world".to_string(),
             link: None,
@@ -129,7 +129,7 @@ mod test {
         transform_link_tag(&mut text);
         assert_eq!(
             text,
-            DocRichText {
+            DocRichTextBlock {
                 tag: Some(prop::LINK.to_string()),
                 text: "hello world".to_string(),
                 link: Some("hello world".to_string()),
@@ -139,7 +139,7 @@ mod test {
 
     #[test]
     fn test_transform_link_tag_with_text() {
-        let mut text = DocRichText {
+        let mut text = DocRichTextBlock {
             tag: Some(prop::LINK.to_string()),
             text: "[hello world] i am link".to_string(),
             link: None,
@@ -147,7 +147,7 @@ mod test {
         transform_link_tag(&mut text);
         assert_eq!(
             text,
-            DocRichText {
+            DocRichTextBlock {
                 tag: Some(prop::LINK.to_string()),
                 text: "hello world".to_string(),
                 // link should be trimmed
@@ -158,7 +158,7 @@ mod test {
 
     #[test]
     fn test_transform_partial_bracket() {
-        let mut text = DocRichText {
+        let mut text = DocRichTextBlock {
             tag: Some(prop::LINK.to_string()),
             text: "[hello world i am link".to_string(),
             link: None,
@@ -166,14 +166,14 @@ mod test {
         transform_link_tag(&mut text);
         assert_eq!(
             text,
-            DocRichText {
+            DocRichTextBlock {
                 tag: Some(prop::LINK.to_string()),
                 text: "[hello world i am link".to_string(),
                 link: Some("[hello world i am link".to_string()),
             }
         );
 
-        let mut text = DocRichText {
+        let mut text = DocRichTextBlock {
             tag: Some(prop::LINK.to_string()),
             text: "abc[hello world] i am link".to_string(),
             link: None,
@@ -181,14 +181,14 @@ mod test {
         transform_link_tag(&mut text);
         assert_eq!(
             text,
-            DocRichText {
+            DocRichTextBlock {
                 tag: Some(prop::LINK.to_string()),
                 text: "abc[hello world] i am link".to_string(),
                 link: Some("abc[hello world] i am link".to_string()),
             }
         );
 
-        let mut text = DocRichText {
+        let mut text = DocRichTextBlock {
             tag: Some(prop::LINK.to_string()),
             text: "abchello world] i am link".to_string(),
             link: None,
@@ -196,7 +196,7 @@ mod test {
         transform_link_tag(&mut text);
         assert_eq!(
             text,
-            DocRichText {
+            DocRichTextBlock {
                 tag: Some(prop::LINK.to_string()),
                 text: "abchello world] i am link".to_string(),
                 link: Some("abchello world] i am link".to_string()),

--- a/compiler-core/src/plug/variables/mod.rs
+++ b/compiler-core/src/plug/variables/mod.rs
@@ -12,7 +12,7 @@ use crate::lang;
 use crate::macros::async_trait;
 use crate::pack::PackerResult;
 use crate::prop;
-use crate::types::{DocColor, DocDiagnostic, DocRichText, DocTag};
+use crate::types::{DocColor, DocDiagnostic, DocRichTextBlock, DocTag};
 use crate::util::yield_budget;
 
 use super::{operation, PlugResult, PluginRuntime};
@@ -152,7 +152,7 @@ impl VariablesPlugin {
     pub fn transform_text(
         &self,
         diagnostics: &mut Vec<DocDiagnostic>,
-        text: &mut DocRichText,
+        text: &mut DocRichTextBlock,
         new_tag: &str,
     ) {
         if let Err(e) = self.transform_text_with_tag(text, new_tag) {
@@ -164,7 +164,11 @@ impl VariablesPlugin {
         }
     }
 
-    fn transform_text_with_tag(&self, text: &mut DocRichText, new_tag: &str) -> Result<(), String> {
+    fn transform_text_with_tag(
+        &self,
+        text: &mut DocRichTextBlock,
+        new_tag: &str,
+    ) -> Result<(), String> {
         let text_ref = &text.text;
         let get_fn = |t: &str| self.get(t);
         text.text = match text.tag.as_ref().map(String::as_ref) {

--- a/compiler-core/src/types.rs
+++ b/compiler-core/src/types.rs
@@ -237,28 +237,6 @@ pub struct DocDiagnostic {
 #[derive_wasm(feature = "wasm")]
 pub struct DocRichText(pub Vec<DocRichTextBlock>);
 
-impl DocRichText {
-    #[inline]
-    pub fn text(text: &str) -> Self {
-        Self(vec![DocRichTextBlock::text(text)])
-    }
-
-    #[inline]
-    pub fn iter(&self) -> impl Iterator<Item=&DocRichTextBlock> {
-        self.0.iter()
-    }
-}
-
-impl IntoIterator for DocRichText {
-    type Item = DocRichTextBlock;
-    type IntoIter = std::vec::IntoIter<Self::Item>;
-
-    #[inline]
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
-
 /// Document rich text block
 #[derive(PartialEq, Default, Serialize, Deserialize, Debug, Clone)]
 #[derive_wasm(feature = "wasm")]
@@ -302,23 +280,6 @@ impl DocRichTextBlock {
 #[derive(PartialEq, Default, Serialize, Deserialize, Debug, Clone)]
 #[derive_wasm(feature = "wasm")]
 pub struct DocPoorText(pub Vec<DocPoorTextBlock>);
-
-impl DocPoorText {
-    #[inline]
-    pub fn iter(&self) -> impl Iterator<Item=&DocPoorTextBlock> {
-        self.0.iter()
-    }
-}
-
-impl IntoIterator for DocPoorText {
-    type Item = DocPoorTextBlock;
-    type IntoIter = std::vec::IntoIter<Self::Item>;
-
-    #[inline]
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
 
 /// Document poor text block. Just text or link
 #[derive(PartialEq, Serialize, Deserialize, Debug, Clone)]

--- a/compiler-core/src/types.rs
+++ b/compiler-core/src/types.rs
@@ -46,7 +46,7 @@ pub struct ExecDoc<'a> {
     /// Project metadata
     pub project: Cow<'a, RouteMetadata>,
     /// The preface
-    pub preface: Vec<Vec<DocRichText>>,
+    pub preface: Vec<DocRichText>,
     /// The route
     pub route: Vec<ExecSection>,
     /// Overall diagnostics (that don't apply to any line)
@@ -187,7 +187,7 @@ pub struct ExecLine {
     /// Line index in section
     pub index: usize,
     /// Primary text content of the line
-    pub text: Vec<DocRichText>,
+    pub text: DocRichText,
     /// Line color
     pub line_color: String,
     /// Corresponding map coordinates
@@ -198,15 +198,17 @@ pub struct ExecLine {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub icon: Option<String>,
     /// Secondary text to show below the primary text
-    pub secondary_text: Vec<DocRichText>,
+    pub secondary_text: DocRichText,
     /// Counter text to display
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub counter_text: Option<DocRichText>,
+    pub counter_text: Option<DocRichTextBlock>,
     /// The notes
     pub notes: Vec<DocNote>,
     /// The split name, if different from text
     #[serde(skip_serializing_if = "Option::is_none")]
     pub split_name: Option<String>,
+    /// If the line text is a banner
+    pub is_banner: bool,
 }
 
 /// Diagnostic message
@@ -215,7 +217,7 @@ pub struct ExecLine {
 #[serde(rename_all = "camelCase")]
 pub struct DocDiagnostic {
     /// The diagnostic message
-    pub msg: Vec<DocPoorText>,
+    pub msg: DocPoorText,
     /// Type of the diagnostic
     ///
     /// The builtin ones are "error" and "warn", but this can be any value.
@@ -228,11 +230,40 @@ pub struct DocDiagnostic {
     pub source: String,
 }
 
-/// Document rich text type
+/// Document rich text
+///
+/// This is a collection of [`DocRichTextBlock`]s
+#[derive(PartialEq, Default, Serialize, Deserialize, Debug, Clone)]
+#[derive_wasm(feature = "wasm")]
+pub struct DocRichText(pub Vec<DocRichTextBlock>);
+
+impl DocRichText {
+    #[inline]
+    pub fn text(text: &str) -> Self {
+        Self(vec![DocRichTextBlock::text(text)])
+    }
+
+    #[inline]
+    pub fn iter(&self) -> impl Iterator<Item=&DocRichTextBlock> {
+        self.0.iter()
+    }
+}
+
+impl IntoIterator for DocRichText {
+    type Item = DocRichTextBlock;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+/// Document rich text block
 #[derive(PartialEq, Default, Serialize, Deserialize, Debug, Clone)]
 #[derive_wasm(feature = "wasm")]
 #[serde(rename_all = "camelCase")]
-pub struct DocRichText {
+pub struct DocRichTextBlock {
     /// The tag name of the text
     ///
     /// Each block only contains one tag
@@ -245,7 +276,7 @@ pub struct DocRichText {
     pub link: Option<String>,
 }
 
-impl DocRichText {
+impl DocRichTextBlock {
     /// Create a rich text block with no tag
     pub fn text(text: &str) -> Self {
         Self {
@@ -265,11 +296,35 @@ impl DocRichText {
     }
 }
 
-/// Document poor text type. Just text or link
+/// Document poor text
+///
+/// This is a collection of [`DocPoorTextBlock`]s
+#[derive(PartialEq, Default, Serialize, Deserialize, Debug, Clone)]
+#[derive_wasm(feature = "wasm")]
+pub struct DocPoorText(pub Vec<DocPoorTextBlock>);
+
+impl DocPoorText {
+    #[inline]
+    pub fn iter(&self) -> impl Iterator<Item=&DocPoorTextBlock> {
+        self.0.iter()
+    }
+}
+
+impl IntoIterator for DocPoorText {
+    type Item = DocPoorTextBlock;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+/// Document poor text block. Just text or link
 #[derive(PartialEq, Serialize, Deserialize, Debug, Clone)]
 #[derive_wasm(feature = "wasm")]
 #[serde(tag = "type", content = "data", rename_all = "camelCase")]
-pub enum DocPoorText {
+pub enum DocPoorTextBlock {
     Text(String),
     Link(String),
 }
@@ -279,7 +334,7 @@ pub enum DocPoorText {
 #[derive_wasm(feature = "wasm")]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum DocNote {
-    Text { content: Vec<DocRichText> },
+    Text { content: DocRichText },
     Image { link: String },
     Video { link: String },
 }

--- a/web-client/src/core/doc/utils.ts
+++ b/web-client/src/core/doc/utils.ts
@@ -1,6 +1,6 @@
 //! Utilities for document
 
-import { DocPoorText, DocRichText, ExecDoc } from "low/celerc";
+import { DocPoorText, DocRichTextBlock, ExecDoc } from "low/celerc";
 
 import {
     DocSettingsState,
@@ -54,15 +54,15 @@ export const getRelativeLocation = (
 };
 
 /// Function to remove the tag from the text and return the just text content
-export const removeTags = (text: Omit<DocRichText, "tag">[]): string => {
+export const removeTags = (text: Omit<DocRichTextBlock, "tag">[]): string => {
     return text.map(removeTag).join("");
 };
 
-export const removeTag = (text: Omit<DocRichText, "tag">): string => {
+export const removeTag = (text: Omit<DocRichTextBlock, "tag">): string => {
     return text.text;
 };
 
 /// Return just the text content of poor texts
-export const removeLinks = (text: DocPoorText[]): string => {
+export const removeLinks = (text: DocPoorText): string => {
     return text.map((t) => t.data).join("");
 };

--- a/web-client/src/ui/doc/DocLine.tsx
+++ b/web-client/src/ui/doc/DocLine.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { Text } from "@fluentui/react-components";
 
 import { viewActions } from "core/store";
-import { DocDiagnostic, DocRichText } from "low/celerc";
+import { DocDiagnostic, DocRichText, DocRichTextBlock } from "low/celerc";
 import { useActions } from "low/store";
 
 import { Rich } from "./Rich";
@@ -26,13 +26,13 @@ type DocLineProps = {
     /// Color of the line
     lineColor: string;
     /// The text to display
-    text: DocRichText[];
+    text: DocRichText;
     /// Url of the icon to display
     iconUrl?: string;
     /// Secondary text
-    secondaryText: DocRichText[];
+    secondaryText: DocRichText;
     /// Counter properties
-    counterText?: DocRichText;
+    counterText?: DocRichTextBlock;
     /// Counter type if any
     counterType?: string;
     /// Diagnostic messages

--- a/web-client/src/ui/doc/Poor.tsx
+++ b/web-client/src/ui/doc/Poor.tsx
@@ -2,12 +2,12 @@
 
 import { Text, TextProps } from "@fluentui/react-components";
 
-import { DocPoorText } from "low/celerc";
+import { DocPoorText, DocPoorTextBlock } from "low/celerc";
 
 /// Poor text display component
 type PoorProps = {
     /// The text to display
-    content: DocPoorText[];
+    content: DocPoorText;
     /// Size of the text
     textProps: TextProps;
 };
@@ -26,7 +26,7 @@ export const Poor: React.FC<PoorProps> = ({ content, textProps }) => {
 };
 
 /// Internal rich text display component
-type PoorBlockProps = DocPoorText & {
+type PoorBlockProps = DocPoorTextBlock & {
     textProps: TextProps;
 };
 

--- a/web-client/src/ui/doc/Rich.tsx
+++ b/web-client/src/ui/doc/Rich.tsx
@@ -3,14 +3,14 @@
 import { Text, TextProps } from "@fluentui/react-components";
 import clsx from "clsx";
 
-import { DocRichText } from "low/celerc";
+import { DocRichText, DocRichTextBlock } from "low/celerc";
 
 import { RichTextClassName, getTagClassName } from "./utils";
 
 /// Rich text display component
 type RichProps = {
     /// The text to display
-    content: DocRichText[];
+    content: DocRichText;
     /// Size of the text
     size: TextProps["size"];
 };
@@ -30,14 +30,12 @@ export const Rich: React.FC<RichProps> = ({ content, size }) => {
 };
 
 /// Internal rich text display component
-type RichBlockProps = DocRichText & {
-    size: TextProps["size"];
-};
+type RichBlockProps = DocRichTextBlock & Partial<TextProps>;
 
-const RichBlock: React.FC<RichBlockProps> = ({ text, tag, link, size }) => {
+const RichBlock: React.FC<RichBlockProps> = ({ text, tag, link, ...rest }) => {
     if (!tag) {
         return (
-            <Text as="span" size={size}>
+            <Text as="span" {...rest}>
                 {text}
             </Text>
         );
@@ -46,8 +44,8 @@ const RichBlock: React.FC<RichBlockProps> = ({ text, tag, link, size }) => {
     return (
         <Text
             as="span"
-            size={size}
             className={clsx(RichTextClassName, tag && getTagClassName(tag))}
+            {...rest}
         >
             {link ? (
                 <a href={link} target="_blank">


### PR DESCRIPTION
Previously the name was confusing since "DocRichText" actually meant individual text blocks, and call sites used Vec<DocRichText>

Now renamed:
- DocRichText -> DocRichTextBlock
- Vec<DocRichText> -> DocRichText

Similar for DocPoorText.

This allows us to implement extended utils for DocRichText type, since we cannot implement functions for Vec